### PR TITLE
add method to enable sending templated emails

### DIFF
--- a/lua-resty-aws-email-0.2-0.rockspec
+++ b/lua-resty-aws-email-0.2-0.rockspec
@@ -14,7 +14,8 @@ dependencies = {
    "lua >= 5.1",
    "xml",
    "lua-resty-http",
-   "lua-resty-aws-auth"
+   "lua-resty-aws-auth",
+   "cjson"
 }
 build = {
    type = "builtin",


### PR DESCRIPTION
New method:
`send_templated(self, email_to, template, data)`
where:
- template: string name of template to use (must be already configured with SES)
- data: string or table representing the JSON data that the template needs

Introduces dependency on `cjson`, in order to be able to convert tables passed as template data to JSON.