### PR TITLE
better email validation

### DIFF
--- a/lib/resty/aws_email.lua
+++ b/lib/resty/aws_email.lua
@@ -104,13 +104,66 @@ function _M.set_destination(email)
   end
 end
 
-function _M.is_email(email)
-  return string.match(tostring(email), '^[%w%.]+@%w+%.[%w%.]+$') ~= nil
+function _M.is_valid_email(email)
+  if email == nil then return nil end
+  if (type(email) ~= 'string') then
+    error("Expected string")
+    return nil
+  end
+  local lastAt = email:find("[^%@]+$")
+  local localPart = email:sub(1, (lastAt - 2)) -- Returns the substring before '@' symbol
+  local domainPart = email:sub(lastAt, #email) -- Returns the substring after '@' symbol
+  -- we werent able to split the email properly
+  if localPart == nil then
+    return nil, "Local name is invalid"
+  end
+
+  if domainPart == nil then
+    return nil, "Domain is invalid"
+  end
+  -- local part is maxed at 64 characters
+  if #localPart > 64 then
+    return nil, "Local name must be less than 64 characters"
+  end
+  -- domains are maxed at 253 characters
+  if #domainPart > 253 then
+    return nil, "Domain must be less than 253 characters"
+  end
+  -- somthing is wrong
+  if lastAt >= 65 then
+    return nil, "Invalid @ symbol usage"
+  end
+  -- quotes are only allowed at the beginning of a the local name
+  local quotes = localPart:find("[\"]")
+  if type(quotes) == 'number' and quotes > 1 then
+    return nil, "Invalid usage of quotes"
+  end
+  -- no @ symbols allowed outside quotes
+  if localPart:find("%@+") and quotes == nil then
+    return nil, "Invalid @ symbol usage in local part"
+  end
+  -- no dot found in domain name
+  if not domainPart:find("%.") then
+    return nil, "No TLD found in domain"
+  end
+  -- only 1 period in succession allowed
+  if domainPart:find("%.%.") then
+    return nil, "Too many periods in domain"
+  end
+  if localPart:find("%.%.") then
+    return nil, "Too many periods in local part"
+  end
+  -- just a general match
+  if not email:match('[%w]*[%p]*%@+[%w]*[%.]?[%w]*') then
+    return nil, "Email pattern test failed"
+  end
+  -- all our tests passed, so we are ok
+  return true
 end
 
 function _M.is_valid_destination(self, email)
   if not email then return false end 
-  if type(email) == 'string' then return self.is_email(email) end
+  if type(email) == 'string' then return self.is_valid_email(email) end
   for k, v in pairs(email) do 
     if not self.is_email(v) then return false end 
   end 


### PR DESCRIPTION
The previous email validation regex did not allow certain characters like `-`.
This seems to be a better comprehensive match.

credits: https://gist.github.com/james2doyle/67846afd05335822c149#file-valid-email-lua